### PR TITLE
Add feature: remove global *http.request maps in favor of request contexts

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -25,7 +25,6 @@ func (ch *clientHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	setClient(r, ch.c)
-	defer clear(r)
 
 	if isSingleLogoutRequest(r) {
 		ch.performSingleLogout(w, r)

--- a/http_helpers.go
+++ b/http_helpers.go
@@ -3,7 +3,6 @@ package cas
 import (
 	"context"
 	"net/http"
-	"sync"
 	"time"
 )
 
@@ -12,12 +11,6 @@ type key int
 const ( // emulating enums is actually pretty ugly in go.
 	clientKey key = iota
 	authenticationResponseKey
-)
-
-var (
-	mutex   sync.RWMutex
-	clients = make(map[*http.Request]*Client)
-	data    = make(map[*http.Request]*AuthenticationResponse)
 )
 
 // setClient associates a Client with a http.Request.
@@ -78,15 +71,6 @@ func getAuthenticationResponse(r *http.Request) *AuthenticationResponse {
 	} else {
 		return nil // explicitly pass along the nil to caller -- conforms to previous impl
 	}
-}
-
-// clear removes the Client and AuthenticationResponse associations of a http.Request.
-func clear(r *http.Request) {
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	delete(clients, r)
-	delete(data, r)
 }
 
 // IsAuthenticated indicates whether the request has been authenticated with CAS.

--- a/http_helpers.go
+++ b/http_helpers.go
@@ -1,9 +1,17 @@
 package cas
 
 import (
+	"context"
 	"net/http"
 	"sync"
 	"time"
+)
+
+type key int
+
+const ( // emulating enums is actually pretty ugly in go.
+	clientKey key = iota
+	authenticationResponseKey
 )
 
 var (
@@ -14,18 +22,18 @@ var (
 
 // setClient associates a Client with a http.Request.
 func setClient(r *http.Request, c *Client) {
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	clients[r] = c
+	ctx := context.WithValue(r.Context(), clientKey, c)
+	r2 := r.WithContext(ctx)
+	*r = *r2
 }
 
 // getClient retrieves the Client associated with the http.Request.
 func getClient(r *http.Request) *Client {
-	mutex.RLock()
-	defer mutex.RUnlock()
-
-	return clients[r]
+	if c := r.Context().Value(clientKey); c != nil {
+		return c.(*Client)
+	} else {
+		return nil // explicitly pass along the nil to caller -- conforms to previous impl
+	}
 }
 
 // RedirectToLogin allows CAS protected handlers to redirect a request
@@ -57,19 +65,19 @@ func RedirectToLogout(w http.ResponseWriter, r *http.Request) {
 // setAuthenticationResponse associates an AuthenticationResponse with
 // a http.Request.
 func setAuthenticationResponse(r *http.Request, a *AuthenticationResponse) {
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	data[r] = a
+	ctx := context.WithValue(r.Context(), authenticationResponseKey, a)
+	r2 := r.WithContext(ctx)
+	*r = *r2
 }
 
 // getAuthenticationResponse retrieves the AuthenticationResponse associated
 // with a http.Request.
 func getAuthenticationResponse(r *http.Request) *AuthenticationResponse {
-	mutex.RLock()
-	defer mutex.RUnlock()
-
-	return data[r]
+	if a := r.Context().Value(authenticationResponseKey); a != nil {
+		return a.(*AuthenticationResponse)
+	} else {
+		return nil // explicitly pass along the nil to caller -- conforms to previous impl
+	}
 }
 
 // clear removes the Client and AuthenticationResponse associations of a http.Request.


### PR DESCRIPTION
##  Why this PR is needed
The current way of accessing the authentication status of a request in `go-cas/cas` is by associating a `*http.Request` with a `*Client` and `*AuthenticationResponse` in global maps which other functions such as `IsAuthenticated(*http.Request)` access. This works well enough for using the `net/http` muxer but many other muxers such as `github.com/gorilla/mux` will pass copies of the `http.request` to the handlers so that when `isAuthenticated(req)` is called inside of a handler there will be no matching key in the global map breaking 

## What changed
Rather than relying on global maps and hoping that downstream muxers do not copy the request, this PR stores the `*Client` and the `*AuthenticationResponse` inside of the request context.  Also note that because the context is scoped to the request so there is no need to call `clear(req)` in `handler.go`

This does not introduce any API changes. All exported functions from `http_helpers.go` act the same and all tests pass.

## Caveats
This PR adds a dependency on the `context` package introduced in Go 1.7. 