### PR TITLE
Unable to validate proxy tickets

### DIFF
--- a/cas_test.go
+++ b/cas_test.go
@@ -82,7 +82,7 @@ func (ts *TestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		return
-	case "/serviceValidate":
+	case "/proxyValidate":
 		ticket := query.Get("ticket")
 		service := query.Get("service")
 

--- a/client.go
+++ b/client.go
@@ -132,9 +132,9 @@ func (c *Client) LogoutUrlForRequest(r *http.Request) (string, error) {
 	return u.String(), nil
 }
 
-// ServiceValidateUrlForRequest determines the CAS serviceValidate URL for the ticket and http.Request.
+// ServiceValidateUrlForRequest determines the CAS proxyValidate URL for the ticket and http.Request.
 func (c *Client) ServiceValidateUrlForRequest(ticket string, r *http.Request) (string, error) {
-	u, err := c.url.Parse(path.Join(c.url.Path, "serviceValidate"))
+	u, err := c.url.Parse(path.Join(c.url.Path, "proxyValidate"))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Problem: I am unable to make a request to validate proxy tickets.

The [CAS 2.0 spec](https://apereo.github.io/cas/4.2.x/protocol/CAS-Protocol-Specification.html#26-proxyvalidate-cas-20) specifies `/proxyValidate` must be capable of validating both service and proxy tickets. The change can be as simple as pointing `(c *Client) ServiceValidateUrlForRequest` to use the proxy URL instead of `serviceValidate`.