### PR TITLE
allow the modification of cas request urls, by using an url scheme

### DIFF
--- a/url_scheme.go
+++ b/url_scheme.go
@@ -1,0 +1,59 @@
+package cas
+
+import (
+	"net/url"
+	"path"
+)
+
+// URLScheme creates the url which are required to handle the cas protocol.
+type URLScheme interface {
+	Login() 		  (*url.URL, error)
+	Logout() 		  (*url.URL, error)
+	Validate() 		  (*url.URL, error)
+	ServiceValidate() (*url.URL, error)
+}
+
+// NewDefaultURLScheme creates a URLScheme which uses the cas default urls
+func NewDefaultURLScheme(base *url.URL) *DefaultURLScheme {
+	return &DefaultURLScheme{
+		base: 				 base,
+		LoginPath: 			 "login",
+		LogoutPath: 	     "logout",
+		ValidatePath: 		 "validate",
+		ServiceValidatePath: "serviceValidate",
+	}
+}
+
+// DefaultURLScheme is a configurable URLScheme. Use NewDefaultURLScheme to create DefaultURLScheme with the default cas
+// urls.
+type DefaultURLScheme struct {
+	base 				*url.URL
+	LoginPath 			string
+	LogoutPath 			string
+	ValidatePath 		string
+	ServiceValidatePath string
+}
+
+// Login returns the url for the cas login page
+func (scheme *DefaultURLScheme) Login() (*url.URL, error) {
+	return scheme.createURL(scheme.LoginPath)
+}
+
+// Logout returns the url for the cas logut page
+func (scheme *DefaultURLScheme) Logout() (*url.URL, error) {
+	return scheme.createURL(scheme.LogoutPath)
+}
+
+// Validate returns the url for the request validation endpoint
+func (scheme *DefaultURLScheme) Validate() (*url.URL, error) {
+	return scheme.createURL(scheme.ValidatePath)
+}
+
+// ServiceValidate returns the url for the service validation endpoint
+func (scheme *DefaultURLScheme) ServiceValidate() (*url.URL, error) {
+	return scheme.createURL(scheme.ServiceValidatePath)
+}
+
+func (scheme *DefaultURLScheme) createURL(urlPath string) (*url.URL, error) {
+	return scheme.base.Parse(path.Join(scheme.base.Path, urlPath))
+}

--- a/url_scheme_test.go
+++ b/url_scheme_test.go
@@ -1,0 +1,30 @@
+package cas
+
+import (
+	"testing"
+	"net/url"
+)
+
+func TestDefaultURLScheme(t *testing.T) {
+	url, _ := url.Parse("https://cas.org/cas")
+	scheme := NewDefaultURLScheme(url)
+
+	u, err := scheme.Login()
+	assertUrl(t, "/cas/login", u, err)
+	u, err = scheme.Logout()
+	assertUrl(t, "/cas/logout", u, err)
+	u, err = scheme.Validate()
+	assertUrl(t, "/cas/validate", u, err)
+	u, err = scheme.ServiceValidate()
+	assertUrl(t, "/cas/serviceValidate", u, err)
+}
+
+func assertUrl(t *testing.T, expected string, u *url.URL, err error) {
+	if err != nil {
+		t.Fatalf("returned error")
+	}
+
+	if expected != u.Path {
+		t.Errorf("%s should be equal to %s", u.Path, expected)
+	}
+}


### PR DESCRIPTION
Hi,
We use an older version of CAS which uses the url */p3/serviceValidate* for CAS 3 service validation. The url */serviceValidate* is used by the CAS 2 protocol, which does not support attributes. So we need a way to change the url for service validation.

In this PR i've introduced a new field URLScheme to the options of the client. The url scheme is responsible for the creation of request urls for the client. With the url scheme every request url can be changed. In our case the code looks like the following:

```go
urlScheme := cas.NewDefaultURLScheme(casUrl)
urlScheme.ServiceValidatePath = path.Join("p3", "serviceValidate")

client := cas.NewClient(&cas.Options{
    URLScheme: urlScheme,
})
```