### PR TITLE
fixed handling of logout request with IssueInstant formatted as ISO8601

### DIFF
--- a/logout_request.go
+++ b/logout_request.go
@@ -24,7 +24,7 @@ func parseLogoutRequest(data []byte) (*logoutRequest, error) {
 		return nil, err
 	}
 
-	t, err := time.Parse(time.RFC1123Z, l.RawIssueInstant)
+	t, err := parseDate(l.RawIssueInstant)
 	if err != nil {
 		return nil, err
 	}
@@ -34,6 +34,18 @@ func parseLogoutRequest(data []byte) (*logoutRequest, error) {
 	l.SessionIndex = strings.TrimSpace(l.SessionIndex)
 
 	return l, nil
+}
+
+func parseDate(raw string) (time.Time, error) {
+	t, err := time.Parse(time.RFC1123Z, raw)
+	if err != nil {
+		// if RFC1123Z does not match, we will try iso8601
+		t, err = time.Parse("2006-01-02T15:04:05Z0700", raw)
+		if err != nil {
+			return t, err
+		}
+	}
+	return t, nil
 }
 
 func newLogoutRequestId() string {

--- a/logout_request_test.go
+++ b/logout_request_test.go
@@ -71,3 +71,24 @@ func TestXmlLayoutRequest(t *testing.T) {
 		t.Errorf("Expected XML to be \n%v\ngot\n%v\n", expected, string(bytes))
 	}
 }
+
+func TestParseLogoutRequestWithISO8601(t *testing.T) {
+	xml := `<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+  ID="8r7834d6r78346s7823d46678235d" Version="2.0" IssueInstant="2018-03-22T10:52:57Z">
+  <saml:NameID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+    @NOT_USED@
+  </saml:NameID>
+  <samlp:SessionIndex>ST-io34f34vr7823vcr82346r782c4b78i2364i76cvr72364rv7263</samlp:SessionIndex>
+</samlp:LogoutRequest>`
+
+	l, err := parseLogoutRequest([]byte(xml))
+	if err != nil {
+		t.Errorf("parseLogoutRequest returned error: %v", err)
+	}
+
+	instant := time.Date(2018, 03, 22, 10, 52, 57, 0, time.UTC)
+	if !instant.Equal(l.IssueInstant) {
+		t.Errorf("Expected IssueInstant to be <%v>, got <%v>",
+			instant, l.IssueInstant)
+	}
+}


### PR DESCRIPTION
Single Sign Out does not work with our CAS version, because our version send the IssueInstant date formatted as ISO8601 instead of RFC1123Z:

```text
ERROR: parsing time "2018-03-22T10:52:57Z" as "Mon, 02 Jan 2006 15:04:05 -0700": cannot parse "2018-03-22T10:52:57Z" as "Mon...
```

With this PR i've try to parse the date with ISO8601, but only if RFC1123Z has failed.