### PR TITLE
Support for the cas rest client

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,7 +3,6 @@ package cas
 import (
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -134,42 +133,20 @@ func (c *Client) LogoutUrlForRequest(r *http.Request) (string, error) {
 
 // ServiceValidateUrlForRequest determines the CAS serviceValidate URL for the ticket and http.Request.
 func (c *Client) ServiceValidateUrlForRequest(ticket string, r *http.Request) (string, error) {
-	u, err := c.url.Parse(path.Join(c.url.Path, "serviceValidate"))
-	if err != nil {
-		return "", err
-	}
-
 	service, err := requestURL(r)
 	if err != nil {
 		return "", err
 	}
-
-	q := u.Query()
-	q.Add("service", sanitisedURLString(service))
-	q.Add("ticket", ticket)
-	u.RawQuery = q.Encode()
-
-	return u.String(), nil
+	return serviceValidateUrl(c.url, ticket, service)
 }
 
 // ValidateUrlForRequest determines the CAS validate URL for the ticket and http.Request.
 func (c *Client) ValidateUrlForRequest(ticket string, r *http.Request) (string, error) {
-	u, err := c.url.Parse(path.Join(c.url.Path, "validate"))
-	if err != nil {
-		return "", err
-	}
-
 	service, err := requestURL(r)
 	if err != nil {
 		return "", err
 	}
-
-	q := u.Query()
-	q.Add("service", sanitisedURLString(service))
-	q.Add("ticket", ticket)
-	u.RawQuery = q.Encode()
-
-	return u.String(), nil
+	return validateUrl(c.url, ticket, service)
 }
 
 // RedirectToLogout replies to the request with a redirect URL to log out of CAS.
@@ -208,129 +185,14 @@ func (c *Client) RedirectToLogin(w http.ResponseWriter, r *http.Request) {
 //
 // If the request returns a 404 then validateTicketCas1 will be returned.
 func (c *Client) validateTicket(ticket string, service *http.Request) error {
-	if glog.V(2) {
-		serviceUrl, _ := requestURL(service)
-		glog.Infof("Validating ticket %v for service %v", ticket, serviceUrl)
-	}
-
-	u, err := c.ServiceValidateUrlForRequest(ticket, service)
+	serviceUrl, err := requestURL(service)
 	if err != nil {
 		return err
 	}
 
-	r, err := http.NewRequest("GET", u, nil)
+	success, err := ValidateTicket(c.client, c.url, ticket, serviceUrl)
 	if err != nil {
 		return err
-	}
-
-	r.Header.Add("User-Agent", "Golang CAS client gopkg.in/cas")
-
-	if glog.V(2) {
-		glog.Infof("Attempting ticket validation with %v", r.URL)
-	}
-
-	resp, err := c.client.Do(r)
-	if err != nil {
-		return err
-	}
-
-	if glog.V(2) {
-		glog.Infof("Request %v %v returned %v",
-			r.Method, r.URL,
-			resp.Status)
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
-		return c.validateTicketCas1(ticket, service)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("cas: validate ticket: %v", string(body))
-	}
-
-	if glog.V(2) {
-		glog.Infof("Received authentication response\n%v", string(body))
-	}
-
-	success, err := ParseServiceResponse(body)
-	if err != nil {
-		return err
-	}
-
-	if glog.V(2) {
-		glog.Infof("Parsed ServiceResponse: %#v", success)
-	}
-
-	if err := c.tickets.Write(ticket, success); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// validateTicketCas1 performs CAS protocol 1 ticket validation.
-func (c *Client) validateTicketCas1(ticket string, service *http.Request) error {
-	u, err := c.ValidateUrlForRequest(ticket, service)
-	if err != nil {
-		return err
-	}
-
-	r, err := http.NewRequest("GET", u, nil)
-	if err != nil {
-		return err
-	}
-
-	r.Header.Add("User-Agent", "Golang CAS client gopkg.in/cas")
-
-	if glog.V(2) {
-		glog.Info("Attempting ticket validation with %v", r.URL)
-	}
-
-	resp, err := c.client.Do(r)
-	if err != nil {
-		return err
-	}
-
-	if glog.V(2) {
-		glog.Info("Request %v %v returned %v",
-			r.Method, r.URL,
-			resp.Status)
-	}
-
-	data, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-
-	if err != nil {
-		return err
-	}
-
-	body := string(data)
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("cas: validate ticket: %v", body)
-	}
-
-	if glog.V(2) {
-		glog.Infof("Received authentication response\n%v", body)
-	}
-
-	if body == "no\n\n" {
-		return nil // not logged in
-	}
-
-	success := &AuthenticationResponse{
-		User: body[4 : len(body)-1],
-	}
-
-	if glog.V(2) {
-		glog.Infof("Parsed ServiceResponse: %#v", success)
 	}
 
 	if err := c.tickets.Write(ticket, success); err != nil {

--- a/rest_client.go
+++ b/rest_client.go
@@ -1,0 +1,147 @@
+package cas
+
+import (
+	"net/url"
+	"net/http"
+	"github.com/golang/glog"
+	"fmt"
+	"path"
+	"io/ioutil"
+)
+
+// https://apereo.github.io/cas/4.2.x/protocol/REST-Protocol.html
+
+// TicketGrantingTicket represents a SSO session for a user, also known as TGT
+type TicketGrantingTicket string
+
+// ServiceTicket stands for the access granted by the CAS server to an application for a specific user, also known as ST
+type ServiceTicket string
+
+
+// RestOptions provide options for the RestClient
+type RestOptions struct {
+	CasURL     *url.URL
+	Client     *http.Client
+}
+
+// RestClient uses the rest protocol provided by cas
+type RestClient struct {
+	casUrl     *url.URL
+	client     *http.Client
+}
+
+// NewRestClient creates a new client for the cas rest protocol with the provided options
+func NewRestClient(options *RestOptions) *RestClient {
+	if glog.V(2) {
+		glog.Infof("cas: new rest client with options %v", options)
+	}
+
+	var client *http.Client
+	if options.Client != nil {
+		client = options.Client
+	} else {
+		client = &http.Client{}
+	}
+
+	return &RestClient{
+		casUrl:      options.CasURL,
+		client:      client,
+	}
+}
+
+// RequestGrantingTicket returns a new TGT, if the username and password authentication was successful
+func (c *RestClient) RequestGrantingTicket(username string, password string) (TicketGrantingTicket, error) {
+	// request:
+	// POST /cas/v1/tickets HTTP/1.0
+	// username=battags&password=password&additionalParam1=paramvalue
+
+	endpoint, err := c.casUrl.Parse(path.Join(c.casUrl.Path, "v1", "tickets"))
+	if err != nil {
+		return "", err
+	}
+
+	values := url.Values{}
+	values.Set("username", username)
+	values.Set("password", password)
+
+	resp, err := c.client.PostForm(endpoint.String(), values)
+	if err != nil {
+		return "", err
+	}
+
+	// response:
+	// 201 Created
+	// Location: http://www.whatever.com/cas/v1/tickets/{TGT id}
+
+	if resp.StatusCode != 201 {
+		return "", fmt.Errorf("ticket endoint returned status code %v", resp.StatusCode)
+	}
+
+	tgt := path.Base(resp.Header.Get("Location"))
+	if tgt == "" {
+		return "", fmt.Errorf("does not return a valid location header")
+	}
+
+	return TicketGrantingTicket(tgt), nil
+}
+
+// RequestServiceTicket requests a service ticket with the TGT for the given service url
+func (c *RestClient) RequestServiceTicket(tgt TicketGrantingTicket, serviceUrl *url.URL) (ServiceTicket, error) {
+	// request:
+	// POST /cas/v1/tickets/{TGT id} HTTP/1.0
+	// service={form encoded parameter for the service url}
+	endpoint, err := c.casUrl.Parse(path.Join(c.casUrl.Path, "v1", "tickets", string(tgt)))
+	if err != nil {
+		return "", err
+	}
+
+	values := url.Values{}
+	values.Set("service", serviceUrl.String())
+
+	resp, err := c.client.PostForm(endpoint.String(), values)
+	if err != nil {
+		return "", err
+	}
+
+	// response:
+	// 200 OK
+	// ST-1-FFDFHDSJKHSDFJKSDHFJKRUEYREWUIFSD2132
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("service ticket endoint returned status code %v", resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return ServiceTicket(data), nil
+}
+
+// Logout destroys the given granting ticket
+func (c *RestClient) Logout(tgt TicketGrantingTicket) error {
+	// DELETE /cas/v1/tickets/TGT-fdsjfsdfjkalfewrihfdhfaie HTTP/1.0
+	endpoint, err := c.casUrl.Parse(path.Join(c.casUrl.Path, "v1", "tickets", string(tgt)))
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("DELETE", endpoint.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != 200 && resp.StatusCode != 204 {
+		return fmt.Errorf("could not destroy granting ticket %v, server returned %v", tgt, resp.StatusCode)
+	}
+
+	return nil
+}

--- a/rest_client.go
+++ b/rest_client.go
@@ -27,9 +27,10 @@ type RestOptions struct {
 
 // RestClient uses the rest protocol provided by cas
 type RestClient struct {
-	casUrl     *url.URL
-	serviceURL *url.URL
-	client     *http.Client
+	casUrl      *url.URL
+	serviceURL  *url.URL
+	client      *http.Client
+	stValidator *ServiceTicketValidator
 }
 
 // NewRestClient creates a new client for the cas rest protocol with the provided options
@@ -49,6 +50,7 @@ func NewRestClient(options *RestOptions) *RestClient {
 		casUrl:      options.CasURL,
 		serviceURL:  options.ServiceURL,
 		client:      client,
+		stValidator: NewServiceTicketValidator(client, options.CasURL),
 	}
 }
 
@@ -126,7 +128,7 @@ func (c *RestClient) RequestServiceTicket(tgt TicketGrantingTicket) (ServiceTick
 
 // ValidateServiceTicket validates the service ticket and returns an AuthenticationResponse
 func (c *RestClient) ValidateServiceTicket(st ServiceTicket) (*AuthenticationResponse, error) {
-	return ValidateTicket(c.client, c.casUrl, string(st), c.serviceURL)
+	return c.stValidator.ValidateTicket(c.serviceURL, string(st))
 }
 
 // Logout destroys the given granting ticket

--- a/rest_client.go
+++ b/rest_client.go
@@ -54,6 +54,19 @@ func NewRestClient(options *RestOptions) *RestClient {
 	}
 }
 
+// Handle wraps a http.Handler to provide CAS Rest authentication for the handler.
+func (c *RestClient) Handle(h http.Handler) http.Handler {
+	return &restClientHandler{
+		c: c,
+		h: h,
+	}
+}
+
+// HandleFunc wraps a function to provide CAS Rest authentication for the handler function.
+func (c *RestClient) HandleFunc(h func(http.ResponseWriter, *http.Request)) http.Handler {
+	return c.Handle(http.HandlerFunc(h))
+}
+
 // RequestGrantingTicket returns a new TGT, if the username and password authentication was successful
 func (c *RestClient) RequestGrantingTicket(username string, password string) (TicketGrantingTicket, error) {
 	// request:

--- a/rest_client_test.go
+++ b/rest_client_test.go
@@ -1,0 +1,149 @@
+package cas
+
+import (
+	"testing"
+	"net/http/httptest"
+	"net/http"
+	"net/url"
+)
+
+func TestRequestGrantingTicket(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cas/v1/tickets" || r.Method != "POST" {
+			w.WriteHeader(404)
+			return
+		}
+
+		if r.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
+			w.WriteHeader(415)
+			return
+		}
+
+		if r.FormValue("username") != "tricia" && r.FormValue("password") != "hitchhiker" {
+			w.WriteHeader(400)
+			return
+		}
+
+		w.Header().Set("Location", "/cas/v1/tickets/TGT-abc")
+		w.WriteHeader(201)
+	}))
+	defer server.Close()
+
+	casUrl, err := url.Parse(server.URL + "/cas/")
+	if err != nil {
+		t.Error("failed to create cas url from test server")
+	}
+
+	restClient := NewRestClient(&RestOptions{
+		CasURL: casUrl,
+		Client: server.Client(),
+	})
+
+	tgt, err := restClient.RequestGrantingTicket("tricia", "hitchhiker")
+	if err != nil {
+		t.Errorf("requesting granting ticket failed: %v", err)
+	}
+
+	if tgt != "TGT-abc" {
+		t.Errorf("expected %s but received %v", "TGT-abc", tgt)
+	}
+
+	_, err = restClient.RequestGrantingTicket("arthur", "dent")
+	if err == nil {
+		t.Errorf("authentication should fail for arthur")
+	}
+}
+
+func TestRequestServiceTicket(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cas/v1/tickets/TGT-abc" || r.Method != "POST" {
+			w.WriteHeader(404)
+			return
+		}
+
+		if r.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
+			w.WriteHeader(415)
+			return
+		}
+
+		if r.FormValue("service") != "https://hitchhiker.com/heartOfGold" {
+			w.WriteHeader(400)
+			return
+		}
+
+		w.WriteHeader(200)
+		w.Write([]byte("ST-123"))
+	}))
+	defer server.Close()
+
+	casUrl, err := url.Parse(server.URL + "/cas/")
+	if err != nil {
+		t.Error("failed to create cas url from test server")
+	}
+
+	restClient := NewRestClient(&RestOptions{
+		CasURL: casUrl,
+		Client: server.Client(),
+	})
+
+	serviceUrl, err := url.Parse("https://hitchhiker.com/heartOfGold")
+	if err != nil {
+		t.Error("failed to create service url")
+	}
+
+	st, err := restClient.RequestServiceTicket(TicketGrantingTicket("TGT-abc"), serviceUrl)
+	if err != nil {
+		t.Errorf("requesting service ticket failed: %v", err)
+	}
+
+	if st != "ST-123" {
+		t.Errorf("expected %s but received %v", "ST-123", st)
+	}
+
+	_, err = restClient.RequestServiceTicket(TicketGrantingTicket("TGT-xyz"), serviceUrl)
+	if err == nil {
+		t.Errorf("service ticket request should fail for TGT-xyz")
+	}
+
+	serviceUrl, err = url.Parse("https://hitchhiker.com/restaurantAtTheEndOfTheUniverse")
+	if err != nil {
+		t.Error("failed to create service url")
+	}
+
+	_, err = restClient.RequestServiceTicket(TicketGrantingTicket("TGT-abc"), serviceUrl)
+	if err == nil {
+		t.Errorf("service ticket request should fail for this service")
+	}
+}
+
+func TestLogout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cas/v1/tickets/TGT-abc" || r.Method != "DELETE" {
+			w.WriteHeader(404)
+			return
+		}
+
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	casUrl, err := url.Parse(server.URL + "/cas/")
+	if err != nil {
+		t.Error("failed to create cas url from test server")
+	}
+
+	restClient := NewRestClient(&RestOptions{
+		CasURL: casUrl,
+		Client: server.Client(),
+	})
+
+	err = restClient.Logout(TicketGrantingTicket("TGT-abc"))
+	if err != nil {
+		t.Errorf("logout failed %v", err)
+	}
+
+	err = restClient.Logout(TicketGrantingTicket("TGT-xyz"))
+	if err == nil {
+		t.Errorf("logout should failed for this TGT")
+	}
+}

--- a/rest_handler.go
+++ b/rest_handler.go
@@ -1,0 +1,59 @@
+package cas
+
+import (
+	"net/http"
+
+	"github.com/golang/glog"
+)
+
+// restClientHandler handles CAS REST Protocol over HTTP Basic Authentication
+type restClientHandler struct {
+	c *RestClient
+	h http.Handler
+}
+
+// ServeHTTP handles HTTP requests, processes HTTP Basic Authentication over CAS Rest api
+// and passes requests up to its child http.Handler.
+func (ch *restClientHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if glog.V(2) {
+		glog.Infof("cas: handling %v request for %v", r.Method, r.URL)
+	}
+
+	username, password, ok := r.BasicAuth()
+	if !ok {
+		w.Header().Set("WWW-Authenticate", "Basic realm=\"CAS Protected Area\"")
+		w.WriteHeader(401)
+		return
+	}
+
+	// TODO we should implement a short cache to avoid hitting cas server on every request
+	// the cache could use the authorization header as key and the authenticationResponse as value
+
+	success, err := ch.authenticate(username, password)
+	if err != nil {
+		if glog.V(1) {
+			glog.Infof("cas: rest authentication failed %v", err)
+		}
+		w.Header().Set("WWW-Authenticate", "Basic realm=\"CAS Protected Area\"")
+		w.WriteHeader(401)
+		return
+	}
+
+	setAuthenticationResponse(r, success)
+	ch.h.ServeHTTP(w, r)
+	return
+}
+
+func (ch *restClientHandler) authenticate(username string, password string) (*AuthenticationResponse, error) {
+	tgt, err := ch.c.RequestGrantingTicket(username, password)
+	if err != nil {
+		return nil, err
+	}
+
+	st, err := ch.c.RequestServiceTicket(tgt)
+	if err != nil {
+		return nil, err
+	}
+
+	return ch.c.ValidateServiceTicket(st)
+}

--- a/service_validate.go
+++ b/service_validate.go
@@ -1,0 +1,161 @@
+package cas
+
+import (
+	"net/url"
+	"path"
+	"net/http"
+	"github.com/golang/glog"
+	"io/ioutil"
+	"fmt"
+)
+
+func ValidateTicket(client *http.Client, casUrl *url.URL, ticket string, serviceUrl *url.URL) (*AuthenticationResponse, error) {
+	if glog.V(2) {
+		glog.Infof("Validating ticket %v for service %v", ticket, serviceUrl)
+	}
+
+	u, err := serviceValidateUrl(casUrl, ticket, serviceUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r.Header.Add("User-Agent", "Golang CAS client gopkg.in/cas")
+
+	if glog.V(2) {
+		glog.Infof("Attempting ticket validation with %v", r.URL)
+	}
+
+	resp, err := client.Do(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if glog.V(2) {
+		glog.Infof("Request %v %v returned %v",
+		r.Method, r.URL,
+		resp.Status)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return validateTicketCas1(client, casUrl, ticket, serviceUrl)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if err != nil {
+			return nil, err
+		}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cas: validate ticket: %v", string(body))
+	}
+
+	if glog.V(2) {
+		glog.Infof("Received authentication response\n%v", string(body))
+	}
+
+	success, err := ParseServiceResponse(body)
+	if err != nil {
+		return nil, err
+	}
+
+	if glog.V(2) {
+		glog.Infof("Parsed ServiceResponse: %#v", success)
+	}
+
+	return success, nil
+}
+
+func serviceValidateUrl(casUrl *url.URL, ticket string, serviceUrl *url.URL) (string, error) {
+	u, err := casUrl.Parse(path.Join(casUrl.Path, "serviceValidate"))
+	if err != nil {
+		return "", err
+	}
+
+	q := u.Query()
+	q.Add("service", sanitisedURLString(serviceUrl))
+	q.Add("ticket", ticket)
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}
+
+func validateUrl(casUrl *url.URL, ticket string, serviceUrl *url.URL) (string, error) {
+	u, err := casUrl.Parse(path.Join(casUrl.Path, "validate"))
+	if err != nil {
+		return "", err
+	}
+
+	q := u.Query()
+	q.Add("service", sanitisedURLString(serviceUrl))
+	q.Add("ticket", ticket)
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}
+
+func validateTicketCas1(client *http.Client, casUrl *url.URL, ticket string, serviceUrl *url.URL) (*AuthenticationResponse, error) {
+	u, err := validateUrl(casUrl, ticket, serviceUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r.Header.Add("User-Agent", "Golang CAS client gopkg.in/cas")
+
+	if glog.V(2) {
+		glog.Info("Attempting ticket validation with %v", r.URL)
+	}
+
+	resp, err := client.Do(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if glog.V(2) {
+		glog.Info("Request %v %v returned %v",
+			r.Method, r.URL,
+			resp.Status)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if err != nil {
+		return nil, err
+	}
+
+	body := string(data)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cas: validate ticket: %v", body)
+	}
+
+	if glog.V(2) {
+		glog.Infof("Received authentication response\n%v", body)
+	}
+
+	if body == "no\n\n" {
+		return nil, nil // not logged in
+	}
+
+	success := &AuthenticationResponse{
+		User: body[4 : len(body)-1],
+	}
+
+	if glog.V(2) {
+		glog.Infof("Parsed ServiceResponse: %#v", success)
+	}
+
+	return success, nil
+}

--- a/url_scheme.go
+++ b/url_scheme.go
@@ -11,6 +11,9 @@ type URLScheme interface {
 	Logout() (*url.URL, error)
 	Validate() (*url.URL, error)
 	ServiceValidate() (*url.URL, error)
+	RestGrantingTicket() (*url.URL, error)
+	RestServiceTicket(tgt string) (*url.URL, error)
+	RestLogout(tgt string) (*url.URL, error)
 }
 
 // NewDefaultURLScheme creates a URLScheme which uses the cas default urls
@@ -21,6 +24,7 @@ func NewDefaultURLScheme(base *url.URL) *DefaultURLScheme {
 		LogoutPath:          "logout",
 		ValidatePath:        "validate",
 		ServiceValidatePath: "serviceValidate",
+		RestEndpoint:        path.Join("v1", "tickets"),
 	}
 }
 
@@ -32,6 +36,7 @@ type DefaultURLScheme struct {
 	LogoutPath          string
 	ValidatePath        string
 	ServiceValidatePath string
+	RestEndpoint        string
 }
 
 // Login returns the url for the cas login page
@@ -52,6 +57,21 @@ func (scheme *DefaultURLScheme) Validate() (*url.URL, error) {
 // ServiceValidate returns the url for the service validation endpoint
 func (scheme *DefaultURLScheme) ServiceValidate() (*url.URL, error) {
 	return scheme.createURL(scheme.ServiceValidatePath)
+}
+
+// RestGrantingTicket returns the url for requesting an granting ticket via rest api
+func (scheme *DefaultURLScheme) RestGrantingTicket() (*url.URL, error) {
+	return scheme.createURL(scheme.RestEndpoint)
+}
+
+// RestServiceTicket returns the url for requesting an service ticket via rest api
+func (scheme *DefaultURLScheme) RestServiceTicket(tgt string) (*url.URL, error) {
+	return scheme.createURL(path.Join(scheme.RestEndpoint, tgt))
+}
+
+// RestLogout returns the url for destroying an granting ticket via rest api
+func (scheme *DefaultURLScheme) RestLogout(tgt string) (*url.URL, error) {
+	return scheme.createURL(path.Join(scheme.RestEndpoint, tgt))
 }
 
 func (scheme *DefaultURLScheme) createURL(urlPath string) (*url.URL, error) {

--- a/url_scheme_test.go
+++ b/url_scheme_test.go
@@ -17,6 +17,12 @@ func TestDefaultURLScheme(t *testing.T) {
 	assertUrl(t, "/cas/validate", u, err)
 	u, err = scheme.ServiceValidate()
 	assertUrl(t, "/cas/serviceValidate", u, err)
+	u, err = scheme.RestGrantingTicket()
+	assertUrl(t, "/cas/v1/tickets", u, err)
+	u, err = scheme.RestServiceTicket("TGT-123")
+	assertUrl(t, "/cas/v1/tickets/TGT-123", u, err)
+	u, err = scheme.RestLogout("TGT-123")
+	assertUrl(t, "/cas/v1/tickets/TGT-123", u, err)
 }
 
 func assertUrl(t *testing.T, expected string, u *url.URL, err error) {


### PR DESCRIPTION
In some situations we have to protect applications with CAS, which are accessed by non browser clients (such as command line applications). Those clients can't use the redirect based CAS workflow.

CAS offers a [REST Protocol](https://apereo.github.io/cas/4.2.x/protocol/REST-Protocol.html) in order to support those clients.

This PR will add a RestClient beside the existing Client and introduces a ServiceTicketValidator in order to share the service ticket validation code between both clients.