### PR TITLE
add support for session store

### DIFF
--- a/service_validate.go
+++ b/service_validate.go
@@ -1,12 +1,13 @@
 package cas
 
 import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"net/url"
 	"path"
-	"net/http"
+
 	"github.com/golang/glog"
-	"io/ioutil"
-	"fmt"
 )
 
 func NewServiceTicketValidator(client *http.Client, casUrl *url.URL) *ServiceTicketValidator {
@@ -53,8 +54,8 @@ func (validator *ServiceTicketValidator) ValidateTicket(serviceUrl *url.URL, tic
 
 	if glog.V(2) {
 		glog.Infof("Request %v %v returned %v",
-		r.Method, r.URL,
-		resp.Status)
+			r.Method, r.URL,
+			resp.Status)
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
@@ -62,11 +63,11 @@ func (validator *ServiceTicketValidator) ValidateTicket(serviceUrl *url.URL, tic
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
+	resp.Body.Close()
 
-		if err != nil {
-			return nil, err
-		}
+	if err != nil {
+		return nil, err
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("cas: validate ticket: %v", string(body))
@@ -118,7 +119,7 @@ func (validator *ServiceTicketValidator) validateTicketCas1(serviceUrl *url.URL,
 	r.Header.Add("User-Agent", "Golang CAS client gopkg.in/cas")
 
 	if glog.V(2) {
-		glog.Info("Attempting ticket validation with %v", r.URL)
+		glog.Infof("Attempting ticket validation with %v", r.URL)
 	}
 
 	resp, err := validator.client.Do(r)
@@ -127,7 +128,7 @@ func (validator *ServiceTicketValidator) validateTicketCas1(serviceUrl *url.URL,
 	}
 
 	if glog.V(2) {
-		glog.Info("Request %v %v returned %v",
+		glog.Infof("Request %v %v returned %v",
 			r.Method, r.URL,
 			resp.Status)
 	}

--- a/session_store.go
+++ b/session_store.go
@@ -1,0 +1,52 @@
+package cas
+
+import "sync"
+
+// SessionStore store the session's ticket
+// SessionID is retrived from cookies
+type SessionStore interface {
+	// Get the ticket with the session id
+	Get(sessionID string) (string, bool)
+
+	// Set the session with a ticket
+	Set(sessionID, ticket string) error
+
+	// Delete the session
+	Delete(sessionID string) error
+}
+
+// NewMemorySessionStore create a default SessionStore that uses memory
+func NewMemorySessionStore() SessionStore {
+	return &memorySessionStore{
+		sessions: make(map[string]string),
+	}
+}
+
+type memorySessionStore struct {
+	mu       sync.RWMutex
+	sessions map[string]string
+}
+
+func (m *memorySessionStore) Get(sessionID string) (string, bool) {
+	m.mu.RLock()
+	ticket, ok := m.sessions[sessionID]
+	m.mu.RUnlock()
+
+	return ticket, ok
+}
+
+func (m *memorySessionStore) Set(sessionID, ticket string) error {
+	m.mu.Lock()
+	m.sessions[sessionID] = ticket
+	m.mu.Unlock()
+
+	return nil
+}
+
+func (m *memorySessionStore) Delete(sessionID string) error {
+	m.mu.Lock()
+	delete(m.sessions, sessionID)
+	m.mu.Unlock()
+
+	return nil
+}

--- a/session_store_test.go
+++ b/session_store_test.go
@@ -1,0 +1,84 @@
+package cas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSessionStore(t *testing.T) {
+	ss := NewMemorySessionStore()
+	require.NotNil(t, ss)
+}
+
+func TestSessionStore_Get(t *testing.T) {
+	ss := NewMemorySessionStore()
+	require.NotNil(t, ss)
+
+	v, ok := ss.Get("key1")
+	require.False(t, ok)
+	require.Equal(t, "", v)
+
+	err := ss.Set("key1", "value1")
+	require.Nil(t, err)
+
+	v, ok = ss.Get("key1")
+	require.True(t, ok)
+	require.Equal(t, "value1", v)
+}
+
+func TestSessionStore_Set(t *testing.T) {
+	ss := NewMemorySessionStore()
+	require.NotNil(t, ss)
+
+	err := ss.Set("key1", "value1")
+	require.Nil(t, err)
+
+	err = ss.Set("key2", "value2")
+	require.Nil(t, err)
+
+	v, ok := ss.Get("key1")
+	require.True(t, ok)
+	require.Equal(t, "value1", v)
+
+	v, ok = ss.Get("key2")
+	require.True(t, ok)
+	require.Equal(t, "value2", v)
+
+	err = ss.Set("key2", "value2-new")
+	require.Nil(t, err)
+
+	v, ok = ss.Get("key2")
+	require.True(t, ok)
+	require.Equal(t, "value2-new", v)
+}
+
+func TestSessionStore_Delete(t *testing.T) {
+	ss := NewMemorySessionStore()
+	require.NotNil(t, ss)
+
+	err := ss.Set("key1", "value1")
+	require.Nil(t, err)
+
+	err = ss.Set("key2", "value2")
+	require.Nil(t, err)
+
+	v, ok := ss.Get("key1")
+	require.True(t, ok)
+	require.Equal(t, "value1", v)
+
+	v, ok = ss.Get("key2")
+	require.True(t, ok)
+	require.Equal(t, "value2", v)
+
+	err = ss.Delete("key2")
+	require.Nil(t, err)
+
+	v, ok = ss.Get("key1")
+	require.True(t, ok)
+	require.Equal(t, "value1", v)
+
+	v, ok = ss.Get("key2")
+	require.False(t, ok)
+	require.Equal(t, "", v)
+}


### PR DESCRIPTION
## Add support for session_store interface

User can define their own session_store implementation to use in a distributed env.

The default implementation is a memory store.