### PR TITLE
support cat server 3.0

### DIFF
--- a/xml_service_response.go
+++ b/xml_service_response.go
@@ -37,11 +37,12 @@ func (p *xmlProxies) AddProxy(proxy string) {
 }
 
 type xmlAttributes struct {
-	XMLName                                xml.Name  `xml:"attributes"`
-	AuthenticationDate                     time.Time `xml:"authenticationDate"`
-	LongTermAuthenticationRequestTokenUsed bool      `xml:"longTermAuthenticationRequestTokenUsed"`
-	IsFromNewLogin                         bool      `xml:"isFromNewLogin"`
-	MemberOf                               []string  `xml:"memberOf"`
+	XMLName                                xml.Name `xml:"attributes"`
+	AuthenticationDate                     time.Time
+	AuthenticationDateStr                  string   `xml:"authenticationDate"`
+	LongTermAuthenticationRequestTokenUsed bool     `xml:"longTermAuthenticationRequestTokenUsed"`
+	IsFromNewLogin                         bool     `xml:"isFromNewLogin"`
+	MemberOf                               []string `xml:"memberOf"`
 	UserAttributes                         *xmlUserAttributes
 	ExtraAttributes                        []*xmlAnyAttribute `xml:",any"`
 }


### PR DESCRIPTION
1. service ticket validation uri is diff in cas3.0, cas2.0 (https://apereo.github.io/cas/5.1.x/protocol/CAS-Protocol-Specification.html#head2.5)

[CAS 3.0] uri
/p3/serviceValidate  (will return user attributes)
[CAS 2.0] uri
/serviceValidate

now our code default use `/serviceValidate`, so I can not get user attributes when cas2.0.

2. user attributes's field `authenticationDate` is zonetime, relate issue is https://github.com/go-cas/cas/issues/19

this pr will resolve two problem





